### PR TITLE
Update CI to use Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '22'
         cache: 'npm'
 
     - name: Install dependencies


### PR DESCRIPTION
## Summary
- Updates the shared CI workflow from Node.js 20 to Node.js 22 to match the SGNL runtime

## Context
The SGNL runner uses Node 22. The CI was hardcoded to Node 20, causing `dist/` mismatches when developers build locally with Node 22.