### PR TITLE
Centralize PR template and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,53 +1,25 @@
-# Organization-wide Dependabot configuration for sgnl-actions
-# This configuration applies to all repositories in the organization
-# that don't have their own dependabot.yml file
-
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    open-pull-requests-limit: 5
-    reviewers:
-      - "erikgustavson"
-    labels:
-      - "dependencies"
-      - "javascript"
+      interval: weekly
     commit-message:
       prefix: "deps"
-      include: "scope"
-    # Group all minor and patch updates together
+    open-pull-requests-limit: 10
     groups:
-      npm-minor-patch:
+      rollup:
         patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-    # Keep major updates separate for careful review
-    ignore:
-      # Don't update Node.js engine version automatically
-      - dependency-name: "node"
-        update-types: ["version-update:semver-major"]
+          - "@rollup/*"
+          - "rollup"
+      eslint:
+        patterns:
+          - "@eslint/*"
+          - "eslint"
 
-  # Enable security updates for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    reviewers:
-      - "erikgustavson"
-    labels:
-      - "dependencies"
-      - "github-actions"
+      interval: weekly
     commit-message:
       prefix: "ci"
-      include: "scope"

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,37 +1,13 @@
-## Description
-<!-- Provide a brief description of the changes in this PR -->
+## Summary
 
-## Type of Change
-<!-- Mark the relevant option with an "x" -->
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
-- [ ] Performance improvement
-- [ ] Code refactoring
-
-## Related Issues
-<!-- Link to related issues -->
-Fixes #(issue number)
-
-## Testing
-<!-- Describe the tests you ran to verify your changes -->
-- [ ] Unit tests pass locally
-- [ ] Integration tests pass
-- [ ] Test coverage is above 80%
-- [ ] Manual testing completed
+<!-- Brief description of what this PR does and why -->
 
 ## Checklist
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published
 
-## Screenshots (if applicable)
-<!-- Add screenshots to help explain your changes -->
-
-## Additional Notes
-<!-- Add any additional notes for reviewers -->
+- [ ] `npm run validate` passes (schema + conformance)
+- [ ] `npm run lint` passes
+- [ ] `npm test` passes
+- [ ] `npm run test:coverage` shows 80%+ coverage
+- [ ] `npm run build` produces up-to-date `dist/index.js`
+- [ ] `metadata.yaml` reflects any input/output changes
+- [ ] README updated if behavior changed


### PR DESCRIPTION
## Summary
- Replaces the generic PR template with the action-specific checklist used by all repos
- Updates org dependabot.yml to match the per-repo config (rollup/eslint groups)

Per-repo copies of `pull_request_template.md` and `dependabot.yml` will be removed from all action repos once this merges — GitHub falls back to the org `.github` repo automatically.