### PR TITLE
Split CI into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,51 @@ on:
   workflow_call:
 
 jobs:
-  test-and-build:
+  validate:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: '22'
         cache: 'npm'
+    - run: npm ci
+    - name: Validate metadata
+      run: npm run validate
 
-    - name: Install dependencies
-      run: npm ci
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - name: Lint
+      run: npm run lint
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - name: Run tests
+      run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
     - name: Verify package-lock.json is in sync
       run: |
         npm install --package-lock-only
@@ -28,24 +57,13 @@ jobs:
           echo "Please run 'npm install' and commit the updated package-lock.json"
           exit 1
         fi
-
-    - name: Validate metadata
-      run: npm run validate
-
-    - name: Lint
-      run: npm run lint
-
-    - name: Run tests
-      run: npm test
-
     - name: Build
       run: npm run build
-
     - name: Verify dist is up-to-date
       run: |
         if [ -n "$(git status --porcelain dist/)" ]; then
           echo "Error: dist/ directory has uncommitted changes after build"
           echo "Please run 'npm run build' and commit the changes"
-          git status --porcelain dist/
+          git diff --stat dist/
           exit 1
         fi


### PR DESCRIPTION
## Summary
- Splits the single `test-and-build` job into 4 parallel jobs: `validate`, `lint`, `test`, `build`
- Each shows as a separate check on PRs for better visibility into what's failing
- `build` job includes package-lock sync and dist verification checks

PR checks will now show:
```
ci / validate  ✓
ci / lint      ✗  ← immediately see lint is the issue
ci / test      ✓
ci / build     ✓
```