### PR TITLE
Fix package-lock.json sync check for git dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - run: npm ci
     - name: Verify package-lock.json is in sync
       run: |
-        npm install --package-lock-only
+        npm install --package-lock-only --prefer-online
         if [ -n "$(git status --porcelain package-lock.json)" ]; then
           echo "Error: package-lock.json is out of sync with package.json"
           echo "Please run 'npm install' and commit the updated package-lock.json"


### PR DESCRIPTION
## Summary
- `npm install --package-lock-only` after `npm ci` reuses cached git resolutions and doesn't re-fetch tags from the remote
- Stale lock files with outdated commit hashes pass the sync check silently
- Adding `--prefer-online` forces npm to re-resolve git refs from the remote, correctly detecting when a lock file points to the wrong commit for a git tag

## Context
Discovered in [sgnl-actions/aad-disable-user#15](https://github.com/sgnl-actions/aad-disable-user/pull/15) — `package.json` referenced `utils#v1.0.7` but `package-lock.json` had the commit hash for `v1.0.6`. CI did not catch it.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Test against a repo with a known stale git dep lock file to confirm detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)