### PR TITLE
Clean npm cache before lock file sync check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
     - run: npm ci
     - name: Verify package-lock.json is in sync
       run: |
+        npm cache clean --force
         npm install --package-lock-only --prefer-online
         if [ -n "$(git status --porcelain package-lock.json)" ]; then
           echo "Error: package-lock.json is out of sync with package.json"


### PR DESCRIPTION
## Summary
- Follows up on #6 — adds `npm cache clean --force` before `npm install --package-lock-only --prefer-online`
- `--prefer-online` could silently fall back to stale cached resolutions if npm is unreachable
- Cleaning the cache first removes the fallback — the check fails loudly on network issues (retryable) rather than silently passing with stale data

Per @goosetav's [review comment](https://github.com/sgnl-actions/.github/pull/6#discussion_r2104195710).

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)