### PR TITLE
Add Active Directory actions to org README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -34,11 +34,11 @@ Actions are executed through SGNL's CAEP Hub feature.
 
 | Service | Action | Description |
 |---------|--------|-------------|
-| Active Directory | [ad-create-user](https://github.com/sgnl-actions/ad-create-user) | Create a new user in on-premise Active Directory |
-| Active Directory | [ad-disable-user](https://github.com/sgnl-actions/ad-disable-user) | Disable an on-premise Active Directory user account |
-| Active Directory | [ad-enable-user](https://github.com/sgnl-actions/ad-enable-user) | Enable an on-premise Active Directory user account |
-| Active Directory | [ad-move-user](https://github.com/sgnl-actions/ad-move-user) | Move a user to a new OU in on-premise Active Directory |
-| Active Directory | [ad-update-user](https://github.com/sgnl-actions/ad-update-user) | Update user attributes in on-premise Active Directory |
+| Active Directory | [ad-create-user](https://github.com/sgnl-actions/ad-create-user) | Create a new user in Active Directory |
+| Active Directory | [ad-disable-user](https://github.com/sgnl-actions/ad-disable-user) | Disable an Active Directory user account |
+| Active Directory | [ad-enable-user](https://github.com/sgnl-actions/ad-enable-user) | Enable an Active Directory user account |
+| Active Directory | [ad-move-user](https://github.com/sgnl-actions/ad-move-user) | Move a user to a new OU in Active Directory |
+| Active Directory | [ad-update-user](https://github.com/sgnl-actions/ad-update-user) | Update user attributes in Active Directory |
 | Azure AD | [aad-disable-user](https://github.com/sgnl-actions/aad-disable-user) | Disable Azure AD user account |
 | Azure AD | [aad-enable-user](https://github.com/sgnl-actions/aad-enable-user) | Enable Azure AD user account |
 | Google | [google-delete-workforce-user](https://github.com/sgnl-actions/google-delete-workforce-user) | Delete Google Workspace user |
@@ -55,9 +55,9 @@ Actions are executed through SGNL's CAEP Hub feature.
 
 | Service | Action | Description |
 |---------|--------|-------------|
-| Active Directory | [ad-add-to-group](https://github.com/sgnl-actions/ad-add-to-group) | Add a user to an on-premise Active Directory group |
-| Active Directory | [ad-create-group](https://github.com/sgnl-actions/ad-create-group) | Create a new group in on-premise Active Directory |
-| Active Directory | [ad-remove-from-group](https://github.com/sgnl-actions/ad-remove-from-group) | Remove a user from an on-premise Active Directory group |
+| Active Directory | [ad-add-to-group](https://github.com/sgnl-actions/ad-add-to-group) | Add a user to an Active Directory group |
+| Active Directory | [ad-create-group](https://github.com/sgnl-actions/ad-create-group) | Create a new group in Active Directory |
+| Active Directory | [ad-remove-from-group](https://github.com/sgnl-actions/ad-remove-from-group) | Remove a user from an Active Directory group |
 | AWS | [aws-add-to-identity-center-group](https://github.com/sgnl-actions/aws-add-to-identity-center-group) | Add user to AWS Identity Center group |
 | AWS | [aws-remove-from-identity-center-group](https://github.com/sgnl-actions/aws-remove-from-identity-center-group) | Remove user from AWS Identity Center group |
 | Azure AD | [aad-add-to-group](https://github.com/sgnl-actions/aad-add-to-group) | Add user to Azure AD group |

--- a/profile/README.md
+++ b/profile/README.md
@@ -34,6 +34,11 @@ Actions are executed through SGNL's CAEP Hub feature.
 
 | Service | Action | Description |
 |---------|--------|-------------|
+| Active Directory | [ad-create-user](https://github.com/sgnl-actions/ad-create-user) | Create a new user in on-premise Active Directory |
+| Active Directory | [ad-disable-user](https://github.com/sgnl-actions/ad-disable-user) | Disable an on-premise Active Directory user account |
+| Active Directory | [ad-enable-user](https://github.com/sgnl-actions/ad-enable-user) | Enable an on-premise Active Directory user account |
+| Active Directory | [ad-move-user](https://github.com/sgnl-actions/ad-move-user) | Move a user to a new OU in on-premise Active Directory |
+| Active Directory | [ad-update-user](https://github.com/sgnl-actions/ad-update-user) | Update user attributes in on-premise Active Directory |
 | Azure AD | [aad-disable-user](https://github.com/sgnl-actions/aad-disable-user) | Disable Azure AD user account |
 | Azure AD | [aad-enable-user](https://github.com/sgnl-actions/aad-enable-user) | Enable Azure AD user account |
 | Google | [google-delete-workforce-user](https://github.com/sgnl-actions/google-delete-workforce-user) | Delete Google Workspace user |
@@ -50,6 +55,9 @@ Actions are executed through SGNL's CAEP Hub feature.
 
 | Service | Action | Description |
 |---------|--------|-------------|
+| Active Directory | [ad-add-to-group](https://github.com/sgnl-actions/ad-add-to-group) | Add a user to an on-premise Active Directory group |
+| Active Directory | [ad-create-group](https://github.com/sgnl-actions/ad-create-group) | Create a new group in on-premise Active Directory |
+| Active Directory | [ad-remove-from-group](https://github.com/sgnl-actions/ad-remove-from-group) | Remove a user from an on-premise Active Directory group |
 | AWS | [aws-add-to-identity-center-group](https://github.com/sgnl-actions/aws-add-to-identity-center-group) | Add user to AWS Identity Center group |
 | AWS | [aws-remove-from-identity-center-group](https://github.com/sgnl-actions/aws-remove-from-identity-center-group) | Remove user from AWS Identity Center group |
 | Azure AD | [aad-add-to-group](https://github.com/sgnl-actions/aad-add-to-group) | Add user to Azure AD group |
@@ -251,6 +259,7 @@ All completed actions are:
 ### By Service
 | Service | Actions | Coverage |
 |---------|---------|----------|
+| Active Directory | 8 | User Lifecycle, Group, Access Management |
 | Okta | 8 | Session, User, Group Management |
 | Azure AD | 7 | Session, User, Group, Role Management |
 | AWS | 4 | Session, Token, Group Management |


### PR DESCRIPTION
## Summary
- Add 8 on-premise Active Directory actions to the organization profile README
- **User Lifecycle Management**: ad-create-user, ad-update-user, ad-enable-user, ad-disable-user, ad-move-user
- **Access Management**: ad-add-to-group, ad-create-group, ad-remove-from-group
- Update the "By Service" summary table with Active Directory (8 actions)

## Test plan
- [x] All 8 action repo links are correct (`sgnl-actions/ad-*`)
- [x] Actions are sorted alphabetically within their categories
- [x] Descriptions are consistent with individual repo READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)