### PR TITLE
Security fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
 
     - name: Compute next version
       id: version
+      env:
+        BUMP_TYPE: ${{ inputs.bump }}
       run: |
         LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
         if [ -z "$LATEST" ]; then
@@ -32,15 +34,19 @@ jobs:
         MINOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f2)
         PATCH=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f3)
 
-        case "${{ inputs.bump }}" in
+        case "$BUMP_TYPE" in
           major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
           minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
           patch) PATCH=$((PATCH + 1)) ;;
+          *)
+            echo "Error: Invalid bump type '$BUMP_TYPE'. Must be major, minor, or patch."
+            exit 1
+            ;;
         esac
 
         TAG="v${MAJOR}.${MINOR}.${PATCH}"
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-        echo "Releasing $TAG (was $LATEST, bump: ${{ inputs.bump }})"
+        echo "Releasing $TAG (was $LATEST, bump: $BUMP_TYPE)"
 
     - name: Configure git
       run: |


### PR DESCRIPTION
## Summary

https://app.aikido.dev/repositories/1204200?sidebarIssue=24521425

TL;DR
Template Injection in GitHub Workflows Action

A GitHub Actions workflow step contains a template expression referencing potentially untrusted GitHub context fields. This may allow malicious input to be injected into shell commands, leading to a potential supply chain attack as tokens of the CI/CD pipeline could be exfiltrated.

[.github/workflows/release.yml](https://github.com/sgnl-actions/.github/blob/main/.github/workflows/release.yml#L25)

Critical
Line 25 - 44 in release.yml

## Checklist

- [ ] `npm run validate` passes (schema + conformance)
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run test:coverage` shows 80%+ coverage
- [ ] `npm run build` produces up-to-date `dist/index.js`
- [ ] `metadata.yaml` reflects any input/output changes
- [ ] README updated if behavior changed
