### PR TITLE
Add sandbox-test to the shared CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,19 @@ jobs:
           git diff --stat dist/
           exit 1
         fi
+
+  sandbox-test:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+      with:
+        deno-version: v2.x
+    - run: npm ci
+    - name: Sandbox test
+      run: npx sgnl-sandbox-test


### PR DESCRIPTION
## Summary

New CLI tool is created in https://github.com/sgnl-actions/testing/pull/15 to run actions in a sandbox for additional verification and testing. Update the CI so run that automatically on every action (each action still needs to update their CI action to this new commit once this PR is merged).

## Checklist

- [ ] `npm run validate` passes (schema + conformance)
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run test:coverage` shows 80%+ coverage
- [ ] `npm run build` produces up-to-date `dist/index.js`
- [ ] `metadata.yaml` reflects any input/output changes
- [ ] README updated if behavior changed
