### PR TITLE
Update sandbox-test action and remove package-lock sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,26 @@ jobs:
         node-version: '22'
         cache: 'npm'
     - run: npm install
+    - name: Verify package-lock.json is in sync
+      run: |
+        cp package-lock.json /tmp/committed-lock.json
+        npm install --package-lock-only --prefer-online
+        node -e "
+          const fs = require('fs');
+          for (const f of ['/tmp/committed-lock.json', 'package-lock.json']) {
+            const lock = JSON.parse(fs.readFileSync(f, 'utf8'));
+            for (const pkg of Object.values(lock.packages || {})) {
+              delete pkg.resolved;
+            }
+            fs.writeFileSync(f, JSON.stringify(lock, null, 2) + '\n');
+          }
+        "
+        if ! diff -q /tmp/committed-lock.json package-lock.json > /dev/null 2>&1; then
+          echo "Error: package-lock.json is out of sync with package.json"
+          echo "Please run 'npm install' and commit the updated package-lock.json"
+          diff /tmp/committed-lock.json package-lock.json | head -50
+          exit 1
+        fi
     - name: Build
       run: npm run build
     - name: Verify dist is up-to-date
@@ -65,13 +85,16 @@ jobs:
     needs: [build]
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: sgnl-actions/action-sandbox
+        path: .action-sandbox
     - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
         node-version: '22'
         cache: 'npm'
-    - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
-      with:
-        deno-version: v2.x
+    - name: Build sandbox container
+      run: docker build -t ghcr.io/sgnl-actions/sandbox-runner:latest .action-sandbox
     - run: npm install
     - name: Sandbox test
       run: npx sgnl-sandbox-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
-    - run: npm ci
+    - run: npm install
     - name: Validate metadata
       run: npm run validate
 
@@ -24,7 +24,7 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
-    - run: npm ci
+    - run: npm install
     - name: Lint
       run: npm run lint
 
@@ -36,7 +36,7 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
-    - run: npm ci
+    - run: npm install
     - name: Run tests
       run: npm test
 
@@ -48,16 +48,7 @@ jobs:
       with:
         node-version: '22'
         cache: 'npm'
-    - run: npm ci
-    - name: Verify package-lock.json is in sync
-      run: |
-        npm cache clean --force
-        npm install --package-lock-only --prefer-online
-        if [ -n "$(git status --porcelain package-lock.json)" ]; then
-          echo "Error: package-lock.json is out of sync with package.json"
-          echo "Please run 'npm install' and commit the updated package-lock.json"
-          exit 1
-        fi
+    - run: npm install
     - name: Build
       run: npm run build
     - name: Verify dist is up-to-date
@@ -81,6 +72,6 @@ jobs:
     - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
       with:
         deno-version: v2.x
-    - run: npm ci
+    - run: npm install
     - name: Sandbox test
       run: npx sgnl-sandbox-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,74 +7,70 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version: "22"
-          cache: "npm"
-      - run: npm ci
-      - name: Validate metadata
-        run: npm run validate
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - name: Validate metadata
+      run: npm run validate
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version: "22"
-          cache: "npm"
-      - run: npm ci
-      - name: Lint
-        run: npm run lint
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - name: Lint
+      run: npm run lint
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version: "22"
-          cache: "npm"
-      - run: npm ci
-      - name: Run tests
-        run: npm test
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - name: Run tests
+      run: npm test
 
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version: "22"
-          cache: "npm"
-      - run: npm ci
-      - name: Build
-        run: npm run build
-      - name: Verify dist is up-to-date
-        run: |
-          if [ -n "$(git status --porcelain dist/)" ]; then
-            echo "Error: dist/ directory has uncommitted changes after build"
-            echo "Please run 'npm run build' and commit the changes"
-            git diff --stat dist/
-            exit 1
-          fi
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - run: npm ci
+    - name: Build
+      run: npm run build
+    - name: Verify dist is up-to-date
+      run: |
+        if [ -n "$(git status --porcelain dist/)" ]; then
+          echo "Error: dist/ directory has uncommitted changes after build"
+          echo "Please run 'npm run build' and commit the changes"
+          git diff --stat dist/
+          exit 1
+        fi
 
   sandbox-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: sgnl-actions/action-sandbox
-          ref: migrate-to-docker # TODO: remove after merging to main
-          path: .action-sandbox
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-        with:
-          node-version: "22"
-          cache: "npm"
-      - name: Build sandbox container
-        run: docker build -t ghcr.io/sgnl-actions/sandbox-runner:latest .action-sandbox
-      - run: npm ci
-      - name: Sandbox test
-        run: npx sgnl-sandbox-test
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      with:
+        node-version: '22'
+        cache: 'npm'
+    - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+      with:
+        deno-version: v2.x
+    - run: npm ci
+    - name: Sandbox test
+      run: npx sgnl-sandbox-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,18 @@ on:
   workflow_call:
 
 jobs:
+  check-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Check for Artifactory references in lockfile
+      run: |
+        if grep -q "artifactory\.cicd\.dc" package-lock.json 2>/dev/null; then
+          echo "::error::package-lock.json contains Artifactory registry references."
+          echo "Please remove the resolved URLs pointing to Artifactory before committing."
+          exit 1
+        fi
+
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: sgnl-actions/action-sandbox
+        ref: migrate-to-docker # TODO: remove after merging to main
+        path: .action-sandbox
     - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:
         node-version: '22'
         cache: 'npm'
-    - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
-      with:
-        deno-version: v2.x
+    - name: Build sandbox container
+      run: docker build -t ghcr.io/sgnl-actions/sandbox-runner:latest .action-sandbox
     - run: npm ci
     - name: Sandbox test
       run: npx sgnl-sandbox-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,94 +7,95 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-      with:
-        node-version: '22'
-        cache: 'npm'
-    - run: npm install
-    - name: Validate metadata
-      run: npm run validate
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Validate metadata
+        run: npm run validate
 
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-      with:
-        node-version: '22'
-        cache: 'npm'
-    - run: npm install
-    - name: Lint
-      run: npm run lint
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Lint
+        run: npm run lint
 
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-      with:
-        node-version: '22'
-        cache: 'npm'
-    - run: npm install
-    - name: Run tests
-      run: npm test
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Run tests
+        run: npm test
 
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-      with:
-        node-version: '22'
-        cache: 'npm'
-    - run: npm install
-    - name: Verify package-lock.json is in sync
-      run: |
-        cp package-lock.json /tmp/committed-lock.json
-        npm install --package-lock-only --prefer-online
-        node -e "
-          const fs = require('fs');
-          for (const f of ['/tmp/committed-lock.json', 'package-lock.json']) {
-            const lock = JSON.parse(fs.readFileSync(f, 'utf8'));
-            for (const pkg of Object.values(lock.packages || {})) {
-              delete pkg.resolved;
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm ci
+      - name: Verify package-lock.json is in sync
+        run: |
+          cp package-lock.json /tmp/committed-lock.json
+          npm install --package-lock-only --prefer-online
+          node -e "
+            const fs = require('fs');
+            for (const f of ['/tmp/committed-lock.json', 'package-lock.json']) {
+              const lock = JSON.parse(fs.readFileSync(f, 'utf8'));
+              for (const pkg of Object.values(lock.packages || {})) {
+                delete pkg.resolved;
+              }
+              fs.writeFileSync(f, JSON.stringify(lock, null, 2) + '\n');
             }
-            fs.writeFileSync(f, JSON.stringify(lock, null, 2) + '\n');
-          }
-        "
-        if ! diff -q /tmp/committed-lock.json package-lock.json > /dev/null 2>&1; then
-          echo "Error: package-lock.json is out of sync with package.json"
-          echo "Please run 'npm install' and commit the updated package-lock.json"
-          diff /tmp/committed-lock.json package-lock.json | head -50
-          exit 1
-        fi
-    - name: Build
-      run: npm run build
-    - name: Verify dist is up-to-date
-      run: |
-        if [ -n "$(git status --porcelain dist/)" ]; then
-          echo "Error: dist/ directory has uncommitted changes after build"
-          echo "Please run 'npm run build' and commit the changes"
-          git diff --stat dist/
-          exit 1
-        fi
+          "
+          if ! diff -q /tmp/committed-lock.json package-lock.json > /dev/null 2>&1; then
+            echo "Error: package-lock.json is out of sync with package.json"
+            echo "Please run 'npm install' and commit the updated package-lock.json"
+            diff /tmp/committed-lock.json package-lock.json | head -50
+            exit 1
+          fi
+      - name: Build
+        run: npm run build
+      - name: Verify dist is up-to-date
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "Error: dist/ directory has uncommitted changes after build"
+            echo "Please run 'npm run build' and commit the changes"
+            git diff --stat dist/
+            exit 1
+          fi
 
   sandbox-test:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: sgnl-actions/action-sandbox
-        path: .action-sandbox
-    - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
-      with:
-        node-version: '22'
-        cache: 'npm'
-    - name: Build sandbox container
-      run: docker build -t ghcr.io/sgnl-actions/sandbox-runner:latest .action-sandbox
-    - run: npm install
-    - name: Sandbox test
-      run: npx sgnl-sandbox-test
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: sgnl-actions/action-sandbox
+          ref: migrate-to-docker # TODO: remove after merging to main
+          path: .action-sandbox
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: "22"
+          cache: "npm"
+      - name: Build sandbox container
+        run: docker build -t ghcr.io/sgnl-actions/sandbox-runner:latest .action-sandbox
+      - run: npm ci
+      - name: Sandbox test
+        run: npx sgnl-sandbox-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: sgnl-actions/action-sandbox
-        ref: migrate-to-docker # TODO: remove after merging to main
         path: .action-sandbox
     - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,26 +49,6 @@ jobs:
           node-version: "22"
           cache: "npm"
       - run: npm ci
-      - name: Verify package-lock.json is in sync
-        run: |
-          cp package-lock.json /tmp/committed-lock.json
-          npm install --package-lock-only --prefer-online
-          node -e "
-            const fs = require('fs');
-            for (const f of ['/tmp/committed-lock.json', 'package-lock.json']) {
-              const lock = JSON.parse(fs.readFileSync(f, 'utf8'));
-              for (const pkg of Object.values(lock.packages || {})) {
-                delete pkg.resolved;
-              }
-              fs.writeFileSync(f, JSON.stringify(lock, null, 2) + '\n');
-            }
-          "
-          if ! diff -q /tmp/committed-lock.json package-lock.json > /dev/null 2>&1; then
-            echo "Error: package-lock.json is out of sync with package.json"
-            echo "Please run 'npm install' and commit the updated package-lock.json"
-            diff /tmp/committed-lock.json package-lock.json | head -50
-            exit 1
-          fi
       - name: Build
         run: npm run build
       - name: Verify dist is up-to-date
@@ -82,7 +62,6 @@ jobs:
 
   sandbox-test:
     runs-on: ubuntu-latest
-    needs: [build]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- `sandbox-test` action now requires a Docker build.
- Remove the `Verify package-lock.json is in sync` since `npm ci` should already check mismatches, see [ref](https://docs.npmjs.com/cli/v9/commands/npm-ci#:~:text=If%20dependencies%20in%20the%20package%20lock%20do%20not%20match%20those%20in%20package.json%2C%20npm%20ci%20will%20exit%20with%20an%20error%2C%20instead%20of%20updating%20the%20package%20lock.). 

## Checklist

- [ ] `npm run validate` passes (schema + conformance)
- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run test:coverage` shows 80%+ coverage
- [ ] `npm run build` produces up-to-date `dist/index.js`
- [ ] `metadata.yaml` reflects any input/output changes
- [ ] README updated if behavior changed
